### PR TITLE
Fixed error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # 318_A2
 Assignment2 for SFU CMPT 318 
 #
-Feature scaling on the data. slice the dataset data and apply the Hidden Markov Model.
+Feature scaling on the data. Slice the dataset data and apply the Hidden Markov Model.


### PR DESCRIPTION
”Slice“ needs to be capitalized at the beginning of a sentence.